### PR TITLE
Update district names in csv file

### DIFF
--- a/scripts/state_district.csv
+++ b/scripts/state_district.csv
@@ -585,7 +585,7 @@ Krishna,547,2016,state,Krishna,district,28
 Guntur,548,2016,state,Guntur,district,28
 Prakasam,549,2016,state,Prakasam,district,28
 Sri Potti Sriramulu Nellore,550,2016,state,Sri Potti Sriramulu Nellore,district,28
-Y.S.R.,551,2016,state,Y.S.R.,district,28
+YSR Kadapa,551,2016,state,YSR Kadapa,district,28
 Kurnool,552,2016,state,Kurnool,district,28
 Anantapur,553,2016,state,Anantapur,district,28
 Chittoor,554,2016,state,Chittoor,district,28
@@ -606,7 +606,7 @@ Shimoga,568,2016,state,Shimoga,district,29
 Udupi,569,2016,state,Udupi,district,29
 Chikmagalur,570,2016,state,Chikmagalur,district,29
 Tumkur,571,2016,state,Tumkur,district,29
-Bangalore,572,2016,state,Bangalore,district,29
+Bangalore Urban,572,2016,state,Bangalore Urban,district,29
 Mandya,573,2016,state,Mandya,district,29
 Hassan,574,2016,state,Hassan,district,29
 Dakshina Kannada,575,2016,state,Dakshina Kannada,district,29


### PR DESCRIPTION
Kadapa, Nellore and Bangalore Urban districts were not showing up
correctly because of differences in names in csv and geojson file.